### PR TITLE
Hide Search block from main manu

### DIFF
--- a/source/03-components/search/search.twig
+++ b/source/03-components/search/search.twig
@@ -10,13 +10,13 @@
 {% set people_id = 'search_type_people'|unique_id %}
 
 <div {{ add_attributes({ class: classes } ) }}>
-  <button class="c-search__button" aria-expanded="true" aria-controls="{{ search_form_id }}">
+  <!-- <button class="c-search__button" aria-expanded="true" aria-controls="{{ search_form_id }}">
     Search
-    {% include '@components/icon/icon.twig' with {
+    {# {% include '@components/icon/icon.twig' with {
       'icon_name': 'search',
       'is_hidden': true
-    } %}
-  </button>
+    } %} #}
+  </button> -->
   <form class="c-search__form" id="{{ search_form_id }}" method="get" hidden tabindex="-1">
     <div class="l-constrain l-constrain--small">
       <div class="c-search__inner">


### PR DESCRIPTION
Fixes tasks [#37479509](https://savaslabs.teamwork.com/#/tasks/37479509)

## Summary of changes

1. Commented code on template that render the search block.

##
**Important:** Code wasn't removed since we should double confirm is that is what client want. Search API is still enable and search page continue working.
##

## To test

- [ ] Pull this branch
- [ ] Run `ddev drush cr`
- [ ] Check [Homepage](https://slac-alpha-d9.ddev.site/home) to see Search block disappear from Main menu.

### Pull request author

As the author, I have verified the following:

- [ ] If I added or edited SCSS or JS in the theme, I compiled assets and included the resulting files as part of my final commit

### Pull request reviewer

As the reviewer, I have verified the following:

- [ ] I have tested the PR locally and/or in a staging environment
- [ ] I have checked `admin/reports/status` to see if there are any errors or warnings introduced by this PR
- [ ] I have run `drush ws` to see if any PHP warnings/errors are generated by the functionality in this PR
